### PR TITLE
Fewer Warnings for Flake 8

### DIFF
--- a/genbadge/utils_flake8.py
+++ b/genbadge/utils_flake8.py
@@ -5,6 +5,7 @@
 from __future__ import division
 
 from warnings import warn
+import os
 import re
 
 from .utils_badge import Badge
@@ -104,7 +105,8 @@ def get_flake8_stats(flake8_stats_file):
     return parse_flake8_stats(flake8_stats_txt)
 
 
-RE_TO_MATCH = re.compile(r"([0-9]+)\s+([A-Z0-9]+)\s.*")
+RE_TO_MATCH = re.compile(r"([0-9]+)\s+([A-Z0-9]+):*\s.*")
+SOURCE_MATCH = re.compile(r"([^:]+):\d+:\s.*")
 
 
 def parse_flake8_stats(stats_txt  # type: str
@@ -115,7 +117,14 @@ def parse_flake8_stats(stats_txt  # type: str
     for line in stats_txt.splitlines():
         match = RE_TO_MATCH.match(line)
         if not match:
-            warn("Line in Flake8 statistics report does not match template and will be ignored: %r" % line)
+            smatch = SOURCE_MATCH.match(line)
+            if smatch:
+                source = smatch.groups()
+                if not os.path.exists(source):
+                    warn("Source report line does not refer to file: %r" %line)
+            else:
+                # warn on lines that do not match stats or source report.
+                warn("Line in Flake8 statistics report does not match template and will be ignored: %r" % line)
         else:
             nb, code = match.groups()
             stats.add(int(nb), code)

--- a/genbadge/utils_flake8.py
+++ b/genbadge/utils_flake8.py
@@ -119,7 +119,7 @@ def parse_flake8_stats(stats_txt  # type: str
         if not match:
             smatch = SOURCE_MATCH.match(line)
             if smatch:
-                source = smatch.groups()
+                source = smatch.group(1)
                 if not os.path.exists(source):
                     warn("Source report line does not refer to file: %r" %line)
             else:

--- a/genbadge/utils_flake8.py
+++ b/genbadge/utils_flake8.py
@@ -106,7 +106,7 @@ def get_flake8_stats(flake8_stats_file):
 
 
 RE_TO_MATCH = re.compile(r"([0-9]+)\s+([A-Z0-9]+):*\s.*")
-SOURCE_MATCH = re.compile(r"([^:]+):\d+:\s.*")
+SOURCE_MATCH = re.compile(r"([^:]+):\d+:\d+:\s+.*")
 
 
 def parse_flake8_stats(stats_txt  # type: str


### PR DESCRIPTION
When I run _genbadge_ for flake8, I notice two things:

* I am using flake8-comments 0.1.2, flake8-type-annotations 0.1.0, and flake8-broken-line 0.4.0 (the latter two by the same author.)  All three output the flake8 code with a colon, which does not match _genbadge_'s flake8 parser and yields a warning.  This patch modifies the regex to allow statistics line with or without that extra colon and quiets the warnings.

```
$ egrep -e '^[0-9]+\s+[A-Z0-9]+[\s:]\s' reports/flake8/flake8stats.txt~manywarnings 
3     CM001: Redundant comment found
4     N400: Found backslash that is used for line breaking
2     T800: Missing spaces between parameter annotation and default value
```
* Also, when I write the output of flake8 --statistics to --output-file, many warnings from _genbadge_ are generated for flake8 output ("Line in Flake8 statistics report does not match template") for the normal lines in the report of the filename, the source line, the column, the code and the message.  Although it might be possible to suppress these, I would prefer to keep them in the output and suppress the warning.  This patch parses lines that do not match _genbadge_'s flake8 template, extracts the filename, and if the filename corresponds to a source file it will suppress the warning as a way to verify that it was a source-related output from flake8 rather than some other type of unexpected output.  Example of a line that triggers the warning.
```
directory/sourcefile.py:139:33: Q000 Single quotes found but double quotes preferred
```

